### PR TITLE
Moved "jms/serializer" dependency to "require" section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "php": "^7.1",
     "guzzlehttp/guzzle": "~6.0",
     "jms/serializer": "~1.9",
-    "simple-bus/jms-serializer-bridge": "^1.0"
+    "simple-bus/jms-serializer-bridge": "^1.0",
+    "indigophp/doctrine-annotation-autoload": "^0.1.0"
   },
   "require-dev": {
     "escapestudios/symfony2-coding-standard": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   "require": {
     "php": "^7.1",
     "guzzlehttp/guzzle": "~6.0",
-    "jms/serializer": "~1.9"
+    "jms/serializer": "~1.9",
+    "simple-bus/jms-serializer-bridge": "^1.0"
   },
   "require-dev": {
     "escapestudios/symfony2-coding-standard": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
   },
   "require": {
     "php": "^7.1",
-    "guzzlehttp/guzzle": "~6.0"
+    "guzzlehttp/guzzle": "~6.0",
+    "jms/serializer": "~1.9"
   },
   "require-dev": {
     "escapestudios/symfony2-coding-standard": "~2.0",
@@ -30,8 +31,6 @@
     "squizlabs/php_codesniffer": "2.6.1",
     "phing/phing": "~2.10",
     "satooshi/php-coveralls": "~0.7",
-    "mikey179/vfsStream": "~1.6.2",
-    "jms/serializer": "~1.9",
-    "simple-bus/jms-serializer-bridge": "^1.0"
+    "mikey179/vfsStream": "~1.6.2"
   }
 }

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -4,6 +4,7 @@ namespace CultuurNet\SearchV3\Serializer;
 
 use CultuurNet\SearchV3\ValueObjects\PagedCollection;
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use JMS\Serializer\DeserializationContext;
 use JMS\Serializer\Naming\IdenticalPropertyNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
@@ -52,6 +53,9 @@ class Serializer implements SerializerInterface
         $serializationContext = SerializationContext::create()
             ->setSerializeNull(true);
 
+        // Register doctrine annotations loader.
+        AnnotationRegistry::registerLoader('class_exists');
+
         return $this->serializer->serialize($object, 'json', $serializationContext);
     }
 
@@ -62,6 +66,9 @@ class Serializer implements SerializerInterface
     {
         $deserializationContext = DeserializationContext::create()
             ->setSerializeNull(true);
+
+        // Register doctrine annotations loader.
+        AnnotationRegistry::registerLoader('class_exists');
 
         return $this->serializer->deserialize($jsonString, PagedCollection::class, 'json', $deserializationContext);
     }


### PR DESCRIPTION
The JMS Serializer library was not being installed because it was in the "require-dev" section of the composer file.