### PR TITLE
Mark calendar summary methods as deprecated

### DIFF
--- a/src/ValueObjects/Offer.php
+++ b/src/ValueObjects/Offer.php
@@ -224,6 +224,7 @@ abstract class Offer
      * @deprecated
      *   There is no calendarSummary property on events/places, so this will always return null in reality.
      *   Will be removed in 2.0
+     *   As a replacement, use https://github.com/cultuurnet/calendar-summary-v3
      */
     public function getCalendarSummary(): ?string
     {
@@ -234,6 +235,7 @@ abstract class Offer
      * @deprecated
      *   There is no calendarSummary property on events/places, so serializing this and sending it to UDB3 does nothing.
      *   Will be removed in 2.0
+     *   No replacement will be provided since there is no functionality for directly setting a calendar summary.
      */
     public function setCalendarSummary(string $calendarSummary): void
     {

--- a/src/ValueObjects/Offer.php
+++ b/src/ValueObjects/Offer.php
@@ -220,11 +220,21 @@ abstract class Offer
         $this->calendarType = $calendarType;
     }
 
+    /**
+     * @deprecated
+     *   There is no calendarSummary property on events/places, so this will always return null in reality.
+     *   Will be removed in 2.0
+     */
     public function getCalendarSummary(): ?string
     {
         return $this->calendarSummary;
     }
 
+    /**
+     * @deprecated
+     *   There is no calendarSummary property on events/places, so serializing this and sending it to UDB3 does nothing.
+     *   Will be removed in 2.0
+     */
     public function setCalendarSummary(string $calendarSummary): void
     {
         $this->calendarSummary = $calendarSummary;


### PR DESCRIPTION
### Added
 
- Added deprecation annotations for `getCalendarSummary()` and `setCalendarSummary()` on `Offer`. In the past there was a `calendarSummary` property on events and places their JSON-LD, but this has been removed for some time already. Instead the `/events/{id}/calsum` and `/places/{id}/calsum` endpoints should be used (not supported by this library right now), or the `cultuurnet/calendar-summary-v3` library to generate it locally.

---

Ticket: https://jira.uitdatabank.be/browse/III-3556

Note: I haven't actually removed this yet and made a 2.0 tag because I thought it might be best to wait a bit in case some other things like this pop up that should be removed. Otherwise we'll be releasing a major version every day, and there's no harm in leaving this for now.
