### PR TITLE
Fix deserialization of old calendar summary property

### DIFF
--- a/src/Serializer/Handler/CalendarSummaryHandler.php
+++ b/src/Serializer/Handler/CalendarSummaryHandler.php
@@ -24,8 +24,12 @@ final class CalendarSummaryHandler implements SubscribingHandlerInterface
         ];
     }
 
-    public function deserializeCalendarSummaryFromJson(JsonDeserializationVisitor $visitor, array $data, array $type, Context $context): CalendarSummary
+    public function deserializeCalendarSummaryFromJson(JsonDeserializationVisitor $visitor, $data, array $type, Context $context): ?CalendarSummary
     {
+        if (!is_array($data)) {
+            return null;
+        }
+
         return new CalendarSummary($data);
     }
 }

--- a/test/Serializer/SerializerTest.php
+++ b/test/Serializer/SerializerTest.php
@@ -77,6 +77,20 @@ final class SerializerTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testDeserializeMethodForResultWithObsoleteCalendarSummaryFormat(): void
+    {
+        $jsonString = file_get_contents(__DIR__ . '/data/search-with-obsolete-calendar-summary-format.json');
+
+        /** @var PagedCollection $actual */
+        $actual = $this->serializer->deserialize($jsonString);
+
+        /** @var Event $actualEvent */
+        $actualEvent = $actual->getMember()->getItems()[0];
+
+        $this->assertNull($actualEvent->getCalendarSummary());
+
+    }
+
     public function testDeserializeMethodForResultsWithEmbedAndFacets(): void
     {
         $jsonString = file_get_contents(__DIR__ . '/data/search-with-embed-and-facets.json');

--- a/test/Serializer/SerializerTest.php
+++ b/test/Serializer/SerializerTest.php
@@ -88,7 +88,6 @@ final class SerializerTest extends TestCase
         $actualEvent = $actual->getMember()->getItems()[0];
 
         $this->assertNull($actualEvent->getCalendarSummary());
-
     }
 
     public function testDeserializeMethodForResultsWithEmbedAndFacets(): void

--- a/test/Serializer/data/search-with-obsolete-calendar-summary-format.json
+++ b/test/Serializer/data/search-with-obsolete-calendar-summary-format.json
@@ -1,0 +1,25 @@
+{
+  "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+  "@type": "PagedCollection",
+  "itemsPerPage": 1,
+  "totalItems": 4,
+  "member": [
+    {
+      "@id": "https://io.uitdatabank.be/event/7438ac58-fb2b-4ddc-bbda-d2d3d61681c5",
+      "@context": "/contexts/event",
+      "calendarSummary": "van x tot y"
+    }
+  ],
+  "facet": {
+    "regions": {
+      "nis-01000": {
+        "name": {
+          "nl": "Brussels Hoofdstedelijk Gewest",
+          "fr": "Région de Bruxelles-Capitale",
+          "de": "Region Brüssel-Hauptstadt"
+        },
+        "count": 4
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Fixed
 
- Made deserialization of `calendarSummary` property more robust in case it does not contain what it expects. (When `embedCalendarSummaries[]=...` is not used, some documents might still contain an old `calendarSummary` property that is a string)
