### PR TITLE
WID-394 Allow multiple advanced queries (again)

### DIFF
--- a/test/SearchQueryTest.php
+++ b/test/SearchQueryTest.php
@@ -8,6 +8,7 @@ use CultuurNet\SearchV3\Parameter\CalendarSummary;
 use CultuurNet\SearchV3\Parameter\Facet;
 use CultuurNet\SearchV3\Parameter\Id;
 use CultuurNet\SearchV3\Parameter\Label;
+use CultuurNet\SearchV3\Parameter\Query;
 use CultuurNet\SearchV3\ValueObjects\CalendarSummaryFormat;
 use PHPUnit\Framework\TestCase;
 
@@ -185,6 +186,57 @@ final class SearchQueryTest extends TestCase
                 'md-html',
                 'lg-text',
             ],
+        ];
+
+        $result = $this->searchQuery->toArray();
+
+        $this->assertEquals($expectedQuery, $result);
+    }
+
+    public function testToArrayMethodWithOneAdvancedQuery(): void
+    {
+        $this->searchQuery->addParameter(new Query('foo:bar'));
+
+        $expectedQuery = [
+            'sort' => [
+                'title' => 'asc',
+            ],
+            'embed' => true,
+            'start' => 10,
+            'limit' => 50,
+            'labels' => 'test-label',
+            'facets' => 'regions',
+            'embedCalendarSummaries' => [
+                'md-html',
+                'lg-text',
+            ],
+            'q' => 'foo:bar',
+        ];
+
+        $result = $this->searchQuery->toArray();
+
+        $this->assertEquals($expectedQuery, $result);
+    }
+
+    public function testToArrayMethodWithMultipleAdvancedQueries(): void
+    {
+        $this->searchQuery->addParameter(new Query('foo:bar'));
+        $this->searchQuery->addParameter(new Query('het depot'));
+
+        $expectedQuery = [
+            'sort' => [
+                'title' => 'asc',
+            ],
+            'embed' => true,
+            'start' => 10,
+            'limit' => 50,
+            'labels' => 'test-label',
+            'facets' => 'regions',
+            'embedCalendarSummaries' => [
+                'md-html',
+                'lg-text',
+            ],
+            'q' => '(foo:bar) AND (het depot)',
         ];
 
         $result = $this->searchQuery->toArray();


### PR DESCRIPTION
### Fixed
 
- Fixed search queries that used multiple `q` parameters. This worked before `v1.0` and was removed because it looked like an incorrect solution for merging multiple parameters of any type, but is needed for projectaanvraag. https://github.com/cultuurnet/search-v3/pull/43/files#diff-1dece7f5843cf04592546ce3035181087e44bdb28f1cf5ab732fa2ffb9e49cefL151-L164
 
---
Ticket: https://jira.uitdatabank.be/browse/WID-394
