### PR TITLE
WID-230 Add support for videos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.1', '7.2', '7.3', '7.4']
+                php-versions: ['7.4']
         name: PHP ${{ matrix.php-versions }}
         steps:
             - name: 📤 Checkout project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             - name: 🐘 Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.1
+                  php-version: 7.4
                   tools: composer
 
             - name: 📦 Install dependencies
@@ -55,7 +55,7 @@ jobs:
         - name: 🐘 Install PHP
           uses: shivammathur/setup-php@v2
           with:
-            php-version: 7.1
+            php-version: 7.4
             tools: composer
 
         - name: 📦 Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": "^7.1",
+    "php": ">=7.4",
     "guzzlehttp/guzzle": "~6.0",
     "jms/serializer": "~1.9",
     "simple-bus/jms-serializer-bridge": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": ">=7.4",
+    "php": "^7.1",
     "guzzlehttp/guzzle": "~6.0",
     "jms/serializer": "~1.9",
     "simple-bus/jms-serializer-bridge": "^1.0",

--- a/src/ValueObjects/Offer.php
+++ b/src/ValueObjects/Offer.php
@@ -115,6 +115,12 @@ abstract class Offer
     private $mediaObjects = [];
 
     /**
+     * @var Video[]
+     * @Type("array<CultuurNet\SearchV3\ValueObjects\Video>")
+     */
+    private $videos = [];
+
+    /**
      * @var Organizer|null
      * @Type("CultuurNet\SearchV3\ValueObjects\Organizer")
      */
@@ -348,6 +354,22 @@ abstract class Offer
     public function setMediaObjects(array $mediaObjects): void
     {
         $this->mediaObjects = $mediaObjects;
+    }
+
+    /**
+     * @return Video[]
+     */
+    public function getVideos(): array
+    {
+        return $this->videos;
+    }
+
+    /**
+     * @param Video[] $videos
+     */
+    public function setVideos(array $videos): void
+    {
+        $this->videos = $videos;
     }
 
     public function getMainMediaObject(): ?MediaObject

--- a/src/ValueObjects/Video.php
+++ b/src/ValueObjects/Video.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\SearchV3\ValueObjects;
+
+use JMS\Serializer\Annotation\Type;
+
+final class Video
+{
+    /**
+     * @var string
+     * @Type("string")
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @Type("string")
+     */
+    private $language;
+
+    /**
+     * @var string
+     * @Type("string")
+     */
+    private $url;
+
+    /**
+     * @var string
+     * @Type("string")
+     */
+    private $embedUrl;
+
+    /**
+     * @var string|null
+     * @Type("string")
+     */
+    private $copyrightHolder;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function setId(string $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    public function setLanguage(string $language): void
+    {
+        $this->language = $language;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(string $url): void
+    {
+        $this->url = $url;
+    }
+
+    public function getEmbedUrl(): string
+    {
+        return $this->embedUrl;
+    }
+
+    public function setEmbedUrl(string $embedUrl): void
+    {
+        $this->embedUrl = $embedUrl;
+    }
+
+    public function getCopyrightHolder(): ?string
+    {
+        return $this->copyrightHolder;
+    }
+
+    public function setCopyrightHolder(?string $copyrightHolder): void
+    {
+        $this->copyrightHolder = $copyrightHolder;
+    }
+}

--- a/test/Serializer/SerializerTest.php
+++ b/test/Serializer/SerializerTest.php
@@ -23,6 +23,7 @@ use CultuurNet\SearchV3\ValueObjects\Status;
 use CultuurNet\SearchV3\ValueObjects\Term;
 use CultuurNet\SearchV3\ValueObjects\TranslatedAddress;
 use CultuurNet\SearchV3\ValueObjects\TranslatedString;
+use CultuurNet\SearchV3\ValueObjects\Video;
 use PHPUnit\Framework\TestCase;
 
 final class SerializerTest extends TestCase
@@ -199,6 +200,20 @@ final class SerializerTest extends TestCase
         $mediaObject->setCopyrightHolder('Lucile Desamory, 2010');
         $event->setMediaObjects([$mediaObject]);
         $event->setImage('https://io.uitdatabank.be/images/e65ef366-65a0-4172-a0fe-6844655ad6b9.jpeg');
+
+        $video1 = new Video();
+        $video1->setId('6d787098-3082-4a0f-a510-1df4597ae02f');
+        $video1->setUrl('https://www.youtube.com/watch?v=cEItmb_a20D');
+        $video1->setEmbedUrl('https://www.youtube.com/embed/cEItmb_a20D');
+        $video1->setLanguage('nl');
+        $video1->setCopyrightHolder('Copyright afgehandeld door YouTube');
+        $video2 = new Video();
+        $video2->setId('192a07d9-049b-4c2a-bc94-e46b7a557529');
+        $video2->setUrl('https://www.youtube.com/watch?v=sXYtmb_q19C');
+        $video2->setEmbedUrl('https://www.youtube.com/embed/sXYtmb_q19C');
+        $video2->setLanguage('fr');
+        $video2->setCopyrightHolder('publiq');
+        $event->setVideos([$video1, $video2]);
 
         $priceInfo = new PriceInfo();
         $priceInfo->setCategory('base');

--- a/test/Serializer/data/search-with-embed-and-facets.json
+++ b/test/Serializer/data/search-with-embed-and-facets.json
@@ -174,6 +174,22 @@
         }
       ],
       "image": "https://io.uitdatabank.be/images/e65ef366-65a0-4172-a0fe-6844655ad6b9.jpeg",
+      "videos": [
+        {
+          "id": "6d787098-3082-4a0f-a510-1df4597ae02f",
+          "url": "https://www.youtube.com/watch?v=cEItmb_a20D",
+          "embedUrl": "https://www.youtube.com/embed/cEItmb_a20D",
+          "language": "nl",
+          "copyrightHolder": "Copyright afgehandeld door YouTube"
+        },
+        {
+          "id": "192a07d9-049b-4c2a-bc94-e46b7a557529",
+          "url": "https://www.youtube.com/watch?v=sXYtmb_q19C",
+          "embedUrl": "https://www.youtube.com/embed/sXYtmb_q19C",
+          "language": "fr",
+          "copyrightHolder": "publiq"
+        }
+      ],
       "organizer": {
         "@type": "Organizer",
         "@id": "https://io.uitdatabank.be/organizers/50c2e3f1-1f40-47a0-a72f-265ede8048fb",


### PR DESCRIPTION
### Added
- Added `video` serialization with annotations

### Changed
- Run GitHub actions only on PHP 7.4

---

**Notes**
- I took the same approach to add getters and setters although a public property could reduce the VOs to very simple DTOs with annotations
- I did not add property type hinting because the `project-aanvraag` Vagrant box is still on PHP 7.1

Ticket: https://jira.uitdatabank.be/browse/WID-230
