### PR TITLE
Parameter hasMediaObjects

### DIFF
--- a/src/Parameter/MediaObject.php
+++ b/src/Parameter/MediaObject.php
@@ -6,9 +6,9 @@ namespace CultuurNet\SearchV3\Parameter;
 
 final class MediaObject extends AbstractParameter
 {
-    public function __construct(bool $hasMediaObject)
+    public function __construct(bool $hasMediaObjects)
     {
-        $this->value = $hasMediaObject;
+        $this->value = $hasMediaObjects;
         $this->key = 'hasMediaObjects';
     }
 }

--- a/src/Parameter/MediaObject.php
+++ b/src/Parameter/MediaObject.php
@@ -9,6 +9,6 @@ final class MediaObject extends AbstractParameter
     public function __construct(bool $hasMediaObject)
     {
         $this->value = $hasMediaObject;
-        $this->key = 'hasMediaObject';
+        $this->key = 'hasMediaObjects';
     }
 }

--- a/test/Parameter/MediaObjectTest.php
+++ b/test/Parameter/MediaObjectTest.php
@@ -15,7 +15,7 @@ final class MediaObjectTest extends TestCase
         $key = $mediaObject->getKey();
         $value = $mediaObject->getValue();
 
-        $this->assertEquals('hasMediaObject', $key);
+        $this->assertEquals('hasMediaObjects', $key);
         $this->assertTrue($value);
     }
 }


### PR DESCRIPTION
### Problem
 
The [documentation](https://documentatie.uitdatabank.be/content/search_api_3/latest/searching/offers/media-objects.html) states that you can use the parameter **hasMediaObjects**. But when trying to add the parameter with the MediaObject class, you'll get the next error:

```json
{
    "title": "Unknown query parameter(s): hasMediaObject",
    "type": "about:blank",
    "status": 400
}
```

### Changed

Changed **hasMediaObject** to **hasMediaObjects** as stated in the documentation.
